### PR TITLE
Fixed typo in in html section

### DIFF
--- a/_includes/table-of-contents.html
+++ b/_includes/table-of-contents.html
@@ -48,7 +48,7 @@
           <span>13</span> lessons
         </small>
         <em>
-          For <strong>designers</strong> willing start coding right away
+          For <strong>designers</strong> willing to start coding right away
         </em>
       </div>
       <ol class="toc-content">


### PR DESCRIPTION
Changed "For <strong>designers</strong> willing start coding right away" to "For <strong>designers</strong> willing to start coding right away"