### PR TITLE
use Rouge as syntax highlighter

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,6 @@
 name: MarkSheet
-highlighter: pygments
+highlighter: rouge
 markdown: kramdown
 kramdown:
   input: GFM
-  syntax_highlighter: pygments
 permalink: :title.html


### PR DESCRIPTION
Github recently announced that GitHub Pages now only supports Rouge, a pure-Ruby syntax highlighter. 

* https://github.com/blog/2100-github-pages-now-faster-and-simpler-with-jekyll-3-0

---

`kramdown:syntax_highlighter` is deprecated. it takes his value of the `highlighter`

:book: kramdown:syntax_highlighter should take value of highlighter:
* https://github.com/jekyll/jekyll/pull/4090