### PR TITLE
fixing padding-bottm typo

### DIFF
--- a/_posts/2015-06-08-css-size-shorthand-wheel.md
+++ b/_posts/2015-06-08-css-size-shorthand-wheel.md
@@ -9,7 +9,7 @@ section: css
 
 When all 4 sides (top, bottom, left and right) are involved in a CSS property, that CSS property also acts as a **shorthand** property.
 
-For example, the `padding` property can be used on its own to apply the _same_ value to all 4 sides, but also comes in 4 variations (`padding-top`, `padding-bottm`, `padding-left` and `padding-right`) to target a specific side.
+For example, the `padding` property can be used on its own to apply the _same_ value to all 4 sides, but also comes in 4 variations (`padding-top`, `padding-bottom`, `padding-left` and `padding-right`) to target a specific side.
 
 {% highlight css %}
 blockquote{ padding: 20px;}


### PR DESCRIPTION
Noticed a very minor typo on css size shorthand wheel page - this PR fixes.

![image](https://cloud.githubusercontent.com/assets/858646/16502451/688647c4-3f06-11e6-9ed4-1a0fb2575030.png)
