### PR TITLE
fix typo in css-selectors

### DIFF
--- a/_posts/2015-04-04-css-selectors.md
+++ b/_posts/2015-04-04-css-selectors.md
@@ -181,7 +181,7 @@ header a {
 }
 {% endhighlight %}
 
-This can be read from right to left as: _"Select all `a` elements that are within a `header` element"_. This will prevent all other links (that aren't in the header) to remain unaffected.
+This can be read from right to left as: _"Select all `a` elements that are within a `header` element"_. This will prevent all other links (that aren't in the header) from being affected.
 
 ### Pseudo-class selectors
 


### PR DESCRIPTION
or "This will allow all other links (that aren't in the header) to remain unaffected.