### PR TITLE
HTTPS -> HTTP (ssl certificate error)

### DIFF
--- a/_posts/2015-09-02-sass-scss-less.md
+++ b/_posts/2015-09-02-sass-scss-less.md
@@ -7,7 +7,7 @@ section: sass
 
 There are 2 CSS preprocessors to choose from:
 
-* **Less** [https://lesscss.org/](https://lesscss.org)
+* **Less** [http://lesscss.org/](http://lesscss.org)
 * **Sass** [https://sass-lang.com/](https://sass-lang.com)
 
 They both have been around for several years. We're going to use **Sass**.


### PR DESCRIPTION
Hello @jgthms ,

During my visit on your website, by accessing to lesscss.org through your hyperlink at 'https://marksheet.io/sass-scss-less.html', I have got certificate issue from lesscss.org itself, with this error code: SSL_ERROR_BAD_CERT_DOMAIN; the certificate is badly signed for github.com, not for lesscss.org.

So, because my web browser warms me about “potential security risk”, visiting the external site by using HTTP only is currently better. Please, can you fix the link in your HTML document?

Thanks and regards.